### PR TITLE
Fixed 'internal integration error' for function binding with ref result

### DIFF
--- a/include/daScript/simulate/interop.h
+++ b/include/daScript/simulate/interop.h
@@ -141,6 +141,13 @@ namespace das
         }
     };
 
+    template <typename Result, typename ...Args>
+    struct ImplCallStaticFunctionImpl<char *, false, false, Result &, Args...> {   // any ref to char * (used in evalPtr)
+        static __forceinline char *call ( Result &(*fn)(Args...), Context & ctx, SimNode ** args ) {
+          return (char *) &CallStaticFunction<Result &,Args...>(fn,ctx,args);;
+        }
+    };
+
     // note: this is here because SimNode_At and such can call evalInt, while index is UInt
     //  this is going to be allowed for now, since the fix will result either in duplicating SimNode_AtU or a cast node
     template <typename ...Args>


### PR DESCRIPTION
Binding function, which returns reference:
const R &func() { ... }

And then calling them in DAS like this, while int interpret mode: let x = func().memberField;

Resulted in 'internal integration error'. Caused by missing template specialization of ImplCallStaticFunctionImpl, for functions with reference results, that would convert result to char* to then be used in evalPtr of SimNode_ExtFuncCall. This commit adds such specialization and fixes the issue.